### PR TITLE
macosx-app executable

### DIFF
--- a/Distribution/MacOSX.hs
+++ b/Distribution/MacOSX.hs
@@ -16,6 +16,7 @@ website, <http://developer.apple.com/>.
 
 module Distribution.MacOSX (
   appBundleBuildHook, appBundleInstallHook,
+  makeAppBundle,
   MacApp(..),
   ChaseDeps(..),
   Exclusions,

--- a/Distribution/MacOSX.hs
+++ b/Distribution/MacOSX.hs
@@ -40,6 +40,7 @@ import System.Info (os)
 import System.Directory (copyFile, createDirectoryIfMissing)
 import System.Exit
 
+import Distribution.MacOSX.AppBuildInfo
 import Distribution.MacOSX.Common
 import Distribution.MacOSX.Dependencies
 
@@ -54,7 +55,7 @@ appBundleBuildHook ::
   -> BuildFlags -> PackageDescription -> LocalBuildInfo -> IO ()
 appBundleBuildHook apps _ _ pkg localb =
   if isMacOS
-     then forM_ apps' $ makeAppBundle localb
+     then forM_ apps' $ makeAppBundle . toAppBuildInfo localb
      else putStrLn "Not OS X, so not building an application bundle."
   where apps' = case apps of
                       [] -> map mkDefault $ executables pkg
@@ -76,7 +77,8 @@ appBundleInstallHook apps _ iflags pkg localb = when isMacOS $ do
   let verbosity = fromFlagOrDefault normal (installVerbosity iflags)
   createDirectoryIfMissing False applicationsDir
   forM_ apps $ \app -> do
-    let appPathSrc = getAppPath localb app
+    let appInfo    = toAppBuildInfo localb app
+        appPathSrc = appPath appInfo
         appPathTgt = applicationsDir </> takeFileName appPathSrc
         exe ap = ap </> pathInApp app (appName app)
     installDirectoryContents verbosity appPathSrc appPathTgt
@@ -99,11 +101,10 @@ isMacOS :: Bool
 isMacOS = os == "darwin"
 
 -- | Given a 'MacApp' in context, make an application bundle in the
--- build area.
-makeAppBundle ::
-  LocalBuildInfo -> MacApp -> IO ()
-makeAppBundle localb app =
-  do appPath <- createAppDir localb app
+-- build area. (for internal use only)
+makeAppBundle :: AppBuildInfo -> IO ()
+makeAppBundle appInfo@(AppBuildInfo appPath _ app) =
+  do createAppDir appInfo
      maybeCopyPlist appPath app
      maybeCopyIcon appPath app
        `catch` \err -> putStrLn ("Warning: could not set up icon for " ++
@@ -115,8 +116,8 @@ makeAppBundle localb app =
 -- | Create application bundle directory structure in build directory
 -- and copy executable into it.  Returns path to newly created
 -- directory.
-createAppDir :: LocalBuildInfo -> MacApp -> IO FilePath
-createAppDir localb app =
+createAppDir :: AppBuildInfo -> IO FilePath
+createAppDir (AppBuildInfo appPath exeSrc app) =
   do putStrLn $ "Creating application bundle directory " ++ appPath
      createDirectoryIfMissing False appPath
      createDirectoryIfMissing True  $ takeDirectory exeDest
@@ -124,12 +125,7 @@ createAppDir localb app =
      putStrLn $ "Copying executable " ++ appName app ++ " into place"
      copyFile exeSrc exeDest
      return appPath
-  where appPath = getAppPath localb app
-        exeDest = appPath </> pathInApp app (appName app)
-        exeSrc = buildDir localb </> appName app </> appName app
-
-getAppPath :: LocalBuildInfo -> MacApp -> FilePath
-getAppPath localb app = buildDir localb </> appName app <.> "app"
+  where exeDest = appPath </> pathInApp app (appName app)
 
 -- | Include any external resources specified.
 includeResources ::

--- a/Distribution/MacOSX/AppBuildInfo.hs
+++ b/Distribution/MacOSX/AppBuildInfo.hs
@@ -1,0 +1,40 @@
+module Distribution.MacOSX.AppBuildInfo where
+
+import Control.Monad (forM_, when)
+import Data.String.Utils (replace)
+import Distribution.PackageDescription (PackageDescription(..),
+                                        Executable(..))
+import Distribution.Simple
+import Distribution.Simple.InstallDirs (bindir, prefix, CopyDest(NoCopyDest))
+import Distribution.Simple.LocalBuildInfo (absoluteInstallDirs, LocalBuildInfo(..))
+import Distribution.Simple.Setup (BuildFlags, InstallFlags,
+                                  fromFlagOrDefault, installVerbosity
+                                 )
+import Distribution.Simple.Utils (installDirectoryContents, installExecutableFile)
+import Distribution.Verbosity (normal)
+import System.Cmd (system)
+import System.FilePath
+import System.Info (os)
+import System.Directory (copyFile, createDirectoryIfMissing)
+import System.Exit
+
+import Distribution.MacOSX.Common
+import Distribution.MacOSX.Dependencies
+
+-- | Information needed to build a bundle
+--
+--   This exists to make it possible to have a standalone
+--   macosx-app executable without it necessarily having to
+--   know a lot of Cabal internals
+data AppBuildInfo = AppBuildInfo
+  { appPath    :: FilePath
+  , appOrigExe :: FilePath
+  , app        :: MacApp
+  }
+
+toAppBuildInfo :: LocalBuildInfo -> MacApp -> AppBuildInfo
+toAppBuildInfo localb app_ = AppBuildInfo
+  { appPath    = buildDir localb </> appName app_ <.> "app"
+  , appOrigExe = buildDir localb </> appName app_ </> appName app_
+  , app        = app_
+  }

--- a/cabal-macosx.cabal
+++ b/cabal-macosx.cabal
@@ -39,3 +39,9 @@ Library
                    Distribution.MacOSX.Dependencies,
                    Distribution.MacOSX.DG
   ghc-options:     -fwarn-tabs -Wall
+
+Executable macosx-app
+  Main-is:         macosx-app.hs
+  Build-Depends:   base >= 4 && < 5, Cabal >= 1.6, directory
+               ,   fgl >= 5.4.2.2 && < 5.5
+               ,   filepath, MissingH, parsec, process

--- a/macosx-app.hs
+++ b/macosx-app.hs
@@ -1,0 +1,29 @@
+module Main where
+
+import Distribution.MacOSX
+import Distribution.MacOSX.AppBuildInfo
+import System.Directory
+import System.Environment
+import System.FilePath
+
+main = do
+  pname <- getProgName
+  xs    <- getArgs
+  exe <- case xs of
+           [x1] -> return x1 
+           _    -> fail $ "Usage: " ++ pname ++ " <exe>"
+  exeExists <- doesFileExist exe
+  let macapp  = MacApp { appName   = takeFileName exe
+                       , appIcon   = Nothing
+                       , appPlist  = Nothing
+                       , resources = []
+                       , otherBins = []
+                       , appDeps   = DoNotChase
+                       } 
+      appInfo = AppBuildInfo { app        = macapp
+                             , appPath    = appName macapp <.> "app"
+                             , appOrigExe = exe
+                             }
+  if exeExists
+     then makeAppBundle appInfo
+     else fail $ exe ++ " does not exist"


### PR DESCRIPTION
This is useful for building things like wxHaskell samples.  It's meant to replace the macosx-app script that used to ship with wxHaskell
