### PR TITLE
Set user write permission on copied dependencies

### DIFF
--- a/Distribution/MacOSX/Dependencies.hs
+++ b/Distribution/MacOSX/Dependencies.hs
@@ -213,6 +213,8 @@ updateDependency ::
 updateDependency appPath app src tgt =
   do putStrLn $ "Updating " ++ newLib ++ "'s dependency on " ++ tgt ++
                    " to " ++ tgt'
+     perm <- getPermissions tgt'
+     setPermissions tgt' (setOwnerWritable True perm)
      let cmd = iTool ++ " -change " ++ show tgt ++ " " ++ show tgt' ++
                    " " ++ show newLib
      --putStrLn cmd

--- a/Distribution/MacOSX/Dependencies.hs
+++ b/Distribution/MacOSX/Dependencies.hs
@@ -190,6 +190,8 @@ copyInDependency appPath app (FDeps src _) =
          do putStrLn $ "Copying " ++ src ++ " to " ++ tgt
             createDirectoryIfMissing True $ takeDirectory tgt
             copyFile src tgt
+            perm <- getPermissions tgt
+            setPermissions tgt (setOwnerWritable True perm)
     where tgt = appPath </> pathInApp app src
 
 -- | Update some object file's library dependencies to point to
@@ -213,8 +215,6 @@ updateDependency ::
 updateDependency appPath app src tgt =
   do putStrLn $ "Updating " ++ newLib ++ "'s dependency on " ++ tgt ++
                    " to " ++ tgt'
-     perm <- getPermissions tgt'
-     setPermissions tgt' (setOwnerWritable True perm)
      let cmd = iTool ++ " -change " ++ show tgt ++ " " ++ show tgt' ++
                    " " ++ show newLib
      --putStrLn cmd

--- a/cabal-macosx.cabal
+++ b/cabal-macosx.cabal
@@ -32,7 +32,7 @@ Source-Repository head
 
 Library
   Build-Depends:   base >= 4 && < 5, Cabal >= 1.6, directory
-               ,   fgl >= 5.4.2.2 && < 5.5
+               ,   fgl >= 5.4.2.2 && < 5.6
                ,   filepath, MissingH, parsec, process
   Exposed-modules: Distribution.MacOSX
   Other-modules:   Distribution.MacOSX.Common,
@@ -44,5 +44,5 @@ Library
 Executable macosx-app
   Main-is:         macosx-app.hs
   Build-Depends:   base >= 4 && < 5, Cabal >= 1.6, directory
-               ,   fgl >= 5.4.2.2 && < 5.5
+               ,   fgl >= 5.4.2.2 && < 5.6
                ,   filepath, MissingH, parsec, process


### PR DESCRIPTION
This allows copying dependencies from the nix store which are read-only.
